### PR TITLE
Launch API

### DIFF
--- a/api/const/api.js
+++ b/api/const/api.js
@@ -1,0 +1,1 @@
+export const API_ENDPOINT_LAUNCH = 'https://lldev.thespacedevs.com/2.2.0/launch/';

--- a/api/launch.js
+++ b/api/launch.js
@@ -1,0 +1,19 @@
+import fetchData from "./middleware/fetchData";
+import { API_ENDPOINT_LAUNCH } from './const/api';
+
+export async function retrieve(id, options) {
+    options = options || {};
+
+    return await fetchData(API_ENDPOINT_LAUNCH + id)
+        .then(data => {
+            const launch = data.results;
+
+            return {
+                id: launch.id,
+                url: launch.url,
+                name: launch.name,
+                status: launch.status.id,
+                rocket: launch.rocket.configuration.name
+            };
+        });
+}

--- a/api/launches.js
+++ b/api/launches.js
@@ -1,0 +1,34 @@
+import fetchData from "./middleware/fetchData";
+import {API_ENDPOINT_LAUNCH} from './const/api';
+
+async function retrieve(options) {
+    options = options || {};
+    const offset = pageToOffset(options.page) || 1;
+    const locations = 'locations' in options ? options.locations.join(',') : [];
+
+    return await fetchData(API_ENDPOINT_LAUNCH, {'location__ids': locations, 'offset': offset})
+        .then(data => {
+            const launches = data.results;
+            const offsetRegex = /offset=(.*)/;
+
+            return {
+                ids: launches.map(launch => launch.id),
+                success: launches.filter(launch => launch.status.id === 3),
+                failure_canaveral_spacex: launches.filter(launch => {
+                    (launch.status.id === 3 || launch.status.id === 7)
+                }).length,
+                previousPage: data.previous ?? offsetToPage(data.previous.match(offsetRegex)[1]),
+                nextPage: data.next ?? offsetToPage(data.next.match(offsetRegex)[1]),
+            };
+        });
+}
+
+function offsetToPage(offset) {
+    return offset / 10;
+}
+
+function pageToOffset(page) {
+    return page * 10;
+}
+
+export default retrieve;

--- a/api/middleware/fetchData.js
+++ b/api/middleware/fetchData.js
@@ -1,0 +1,19 @@
+const fetchOptions = {
+    crossDomain: true,
+    method: 'GET',
+    header: {'Content-Type': 'application/json'},
+}
+
+async function fetchData(endpoint, params) {
+    const queryString = params ? '?' + Object.keys(params).map(key => key + '=' + params[key]).join('&') : null;
+
+    const response = await fetch(endpoint + queryString, fetchOptions);
+
+    if (response.ok) {
+        return await response.json();
+    } else {
+        console.log('HTTP error: ' + response.status);
+    }
+}
+
+export default fetchData;

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,5 +1,6 @@
 import Head from 'next/head'
 import styles from '../styles/Home.module.css'
+import Launch from "./launch";
 
 const Home = ()  => {
   return (
@@ -11,14 +12,10 @@ const Home = ()  => {
 
       <main className={styles.main}>
         <h1 className={styles.title}>
-          Welcome !
+          🚀
         </h1>
 
-        <p className={styles.description}>
-          Get started by editing{' '}
-          <code className={styles.code}>pages/index.js</code>
-        </p>
-
+        <Launch></Launch>
       </main>
 
     </div>

--- a/pages/launch.js
+++ b/pages/launch.js
@@ -1,0 +1,27 @@
+import retrieve from '../api/launches';
+import {useEffect, useState} from 'react';
+
+const Launch = () => {
+    const [launches, setLaunches] = useState(null);
+    const [page, setPage] = useState(1);
+
+    useEffect(async () => {
+        await retrieve({page: page, locations: [12, 143]})
+            .then(function (fetched) {
+                setLaunches(fetched);
+            });
+    }, []);
+
+    return (
+        <>
+            {/* could be a better UX 🙈 */}
+            <ul>
+                {launches && launches.ids.map((id) => (
+                    <li key={id}>{id}</li>
+                ))}
+            </ul>
+        </>
+    );
+};
+
+export default Launch;


### PR DESCRIPTION
The aim of thi PR is to create a middleware, allowing to exploit the data of The Space Devs APIs.

The new *api* folder contains methods to retrieve launches entities, and a unique launch entity (based on his ID). The architecture is a kind of pattern factory, where each method exposes a `retrieve` function to fetch the data.
This could be further improved, for example by having a set of methods that can be used at any time, such as page/offset manipulations, sorting, filtering, etc.

The data asked by the exercise, consisting only of IDs, is not usable as is in an UI. Ideally, these methods should return more complete objects so that the interface displays truly useful data.